### PR TITLE
Fix button materials and make menu slots configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>at.dergamer09</groupId>
     <artifactId>Changelog</artifactId>
-    <version>1.0.5-SNAPSHOT</version>
+    <version>1.0.7-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Changelog</name>

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,15 +26,18 @@ navigation:
   previous:
     material: "FEATHER"
     display_name: "&aPrevious Page"
+    slot: 48
     lore:
       - "&7Click to go back"
   next:
     material: "FEATHER"
     display_name: "&aNext Page"
+    slot: 50
     lore:
       - "&7Click to go forward"
 
 entries_per_page: 10 # Defines how many changelog entries fit in one menu before creating a new page.
+entry_item_material: "WRITABLE_BOOK" # Material for each changelog entry item.
 
 gui_border:
   enabled: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Changelog
-version: '1.0.5-SNAPSHOT'
+version: '1.0.7-SNAPSHOT'
 main: at.dergamer09.changelog.Changelog
 api-version: '1.21'
 authors: [ DerGamer09 ]


### PR DESCRIPTION
## Summary
- allow configuring navigation button slots
- support custom materials for navigation and close buttons at runtime
- use configured display names for buttons when present
- bump version to 1.0.7-SNAPSHOT and add newline to plugin.yml

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68607faccd4c832eb452eeaa26c592ef