### PR TITLE
Fix YAML indentation for config

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -57,7 +57,7 @@ changelog:
     date: "&703.03.2025"
     content:
       - "&7Ein neuer Monat bringt neue &eKisten&7!"
-        - "&fFreut euch auf die &cSchmelzpicke V4&f, die wirklich alles schmelzen kann, und &9Titanschlag&f, den neuen Streitkolben aus der &e1.21.6&f."
+      - "&fFreut euch auf die &cSchmelzpicke V4&f, die wirklich alles schmelzen kann, und &9Titanschlag&f, den neuen Streitkolben aus der &e1.21.6&f."
       - "&fAußerdem neu: &dRiesen-& und &5Zwergpilze&f, mit denen ihr eure Größe verändern könnt!"
       - "&fDas und vieles mehr gibt es jetzt in den neuen Kisten. Sichert sie euch und genießt die ersten warmen Tage mit &4OPSUCHT&f!"
 


### PR DESCRIPTION
## Summary
- fix incorrect indentation that broke YAML parsing

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a75a939c0832e8370ccfab013e9e6