### PR TITLE
Implement SQL-based changelog plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Changelog Plugin
+
+This plugin provides a simple changelog system with a paged GUI. Entries are stored in a database (SQLite or MySQL).
+
+## Commands
+- `/changelog` – open the changelog GUI.
+- `/changelog add <text>` – add a new entry. Requires `changelog.admin`.
+- `/changelog remove <id>` – remove an entry. Requires `changelog.admin`.
+- `/changelog list` – list all entries in chat/console. Requires `changelog.admin`.
+
+The GUI shows up to 36 entries per page with arrows to navigate and a close button.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>at.dergamer09</groupId>
+    <artifactId>Changelog</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+            </resource>
+        </resources>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>spigotmc-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.21-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.43.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>8.0.33</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/main/java/at/dergamer09/changelog/ChangelogCommand.java
+++ b/src/main/java/at/dergamer09/changelog/ChangelogCommand.java
@@ -1,0 +1,87 @@
+package at.dergamer09.changelog;
+
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class ChangelogCommand implements CommandExecutor {
+    private final ChangelogPlugin plugin;
+
+    public ChangelogCommand(ChangelogPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (args.length == 0) {
+            if (sender instanceof Player player) {
+                plugin.getServer().getScheduler().runTaskAsynchronously(plugin, () -> {
+                    new ChangelogGUI(plugin).open(player, 0);
+                });
+            } else {
+                sender.sendMessage(ChatColor.RED + "Only players can open the GUI.");
+            }
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("add")) {
+            if (!sender.hasPermission("changelog.admin")) {
+                sender.sendMessage(ChatColor.RED + "No permission.");
+                return true;
+            }
+            if (args.length < 2) {
+                sender.sendMessage(ChatColor.RED + "/changelog add <Text>");
+                return true;
+            }
+            String text = String.join(" ", java.util.Arrays.copyOfRange(args, 1, args.length));
+            plugin.getDatabase().addEntry(text);
+            sender.sendMessage(ChatColor.GREEN + "Entry added.");
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("remove")) {
+            if (!sender.hasPermission("changelog.admin")) {
+                sender.sendMessage(ChatColor.RED + "No permission.");
+                return true;
+            }
+            if (args.length < 2) {
+                sender.sendMessage(ChatColor.RED + "/changelog remove <ID>");
+                return true;
+            }
+            try {
+                int id = Integer.parseInt(args[1]);
+                plugin.getDatabase().removeEntry(id);
+                sender.sendMessage(ChatColor.GREEN + "Entry removed.");
+            } catch (NumberFormatException e) {
+                sender.sendMessage(ChatColor.RED + "Invalid ID.");
+            }
+            return true;
+        }
+
+        if (args[0].equalsIgnoreCase("list")) {
+            if (!sender.hasPermission("changelog.admin")) {
+                sender.sendMessage(ChatColor.RED + "No permission.");
+                return true;
+            }
+            try {
+                ResultSet rs = plugin.getDatabase().getEntries();
+                while (rs.next()) {
+                    int id = rs.getInt("id");
+                    String date = rs.getString("date");
+                    String msg = rs.getString("message");
+                    sender.sendMessage("#" + id + " [" + date + "] " + msg);
+                }
+            } catch (SQLException e) {
+                sender.sendMessage("Error reading entries.");
+            }
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/at/dergamer09/changelog/ChangelogGUI.java
+++ b/src/main/java/at/dergamer09/changelog/ChangelogGUI.java
@@ -1,0 +1,110 @@
+package at.dergamer09.changelog;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChangelogGUI implements Listener {
+    private final ChangelogPlugin plugin;
+
+    public ChangelogGUI(ChangelogPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void open(Player player, int page) {
+        int entriesPerPage = 36;
+        List<ItemStack> items = new ArrayList<>();
+        try {
+            ResultSet rs = plugin.getDatabase().getEntries();
+            while (rs.next()) {
+                String date = rs.getString("date");
+                String msg = rs.getString("message");
+                ItemStack book = new ItemStack(Material.BOOK);
+                ItemMeta meta = book.getItemMeta();
+                if (meta != null) {
+                    meta.setDisplayName(ChatColor.GRAY + date + ChatColor.WHITE + " " + msg);
+                    book.setItemMeta(meta);
+                }
+                items.add(book);
+            }
+        } catch (SQLException e) {
+            player.sendMessage(ChatColor.RED + "Error loading changelog.");
+            return;
+        }
+        int maxPages = (int) Math.ceil(items.size() / (double) entriesPerPage);
+        if (page < 0) page = 0;
+        if (page >= maxPages) page = maxPages - 1;
+        if (maxPages == 0) maxPages = 1;
+
+        Inventory inv = Bukkit.createInventory(null, 54, ChatColor.DARK_PURPLE + "Changelog " + (page + 1) + "/" + maxPages);
+        int start = page * entriesPerPage;
+        for (int i = 0; i < entriesPerPage; i++) {
+            int index = start + i;
+            if (index >= items.size()) break;
+            inv.setItem(i, items.get(index));
+        }
+        // navigation
+        ItemStack prev = new ItemStack(Material.ARROW);
+        ItemMeta pm = prev.getItemMeta();
+        if (pm != null) {
+            pm.setDisplayName(ChatColor.GREEN + "Previous");
+            prev.setItemMeta(pm);
+        }
+        inv.setItem(45, prev);
+
+        ItemStack next = new ItemStack(Material.ARROW);
+        ItemMeta nm = next.getItemMeta();
+        if (nm != null) {
+            nm.setDisplayName(ChatColor.GREEN + "Next");
+            next.setItemMeta(nm);
+        }
+        inv.setItem(53, next);
+
+        ItemStack close = new ItemStack(Material.BARRIER);
+        ItemMeta cm = close.getItemMeta();
+        if (cm != null) {
+            cm.setDisplayName(ChatColor.RED + "Close");
+            close.setItemMeta(cm);
+        }
+        inv.setItem(49, close);
+
+        player.openInventory(inv);
+    }
+
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if (event.getView().getTitle().startsWith(ChatColor.DARK_PURPLE + "Changelog")) {
+            event.setCancelled(true);
+            Player player = (Player) event.getWhoClicked();
+            String title = ChatColor.stripColor(event.getView().getTitle());
+            String[] split = title.split(" ");
+            int page = 0;
+            if (split.length > 1) {
+                String[] p = split[1].split("/");
+                if (p.length > 0) {
+                    page = Integer.parseInt(p[0]) - 1;
+                }
+            }
+            int slot = event.getRawSlot();
+            if (slot == 45) {
+                open(player, page - 1);
+            } else if (slot == 53) {
+                open(player, page + 1);
+            } else if (slot == 49) {
+                player.closeInventory();
+            }
+        }
+    }
+}

--- a/src/main/java/at/dergamer09/changelog/ChangelogPlugin.java
+++ b/src/main/java/at/dergamer09/changelog/ChangelogPlugin.java
@@ -1,0 +1,28 @@
+package at.dergamer09.changelog;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+public class ChangelogPlugin extends JavaPlugin {
+
+    private DatabaseManager databaseManager;
+
+    @Override
+    public void onEnable() {
+        saveDefaultConfig();
+        databaseManager = new DatabaseManager(this);
+        databaseManager.init();
+        getCommand("changelog").setExecutor(new ChangelogCommand(this));
+        getServer().getPluginManager().registerEvents(new ChangelogGUI(this), this);
+    }
+
+    @Override
+    public void onDisable() {
+        if (databaseManager != null) {
+            databaseManager.close();
+        }
+    }
+
+    public DatabaseManager getDatabase() {
+        return databaseManager;
+    }
+}

--- a/src/main/java/at/dergamer09/changelog/DatabaseManager.java
+++ b/src/main/java/at/dergamer09/changelog/DatabaseManager.java
@@ -1,0 +1,88 @@
+package at.dergamer09.changelog;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.io.File;
+import java.sql.*;
+
+public class DatabaseManager {
+    private final ChangelogPlugin plugin;
+    private Connection connection;
+
+    public DatabaseManager(ChangelogPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    public void init() {
+        FileConfiguration config = plugin.getConfig();
+        String type = config.getString("database.type", "sqlite");
+        try {
+            if (type.equalsIgnoreCase("mysql")) {
+                String host = config.getString("database.host", "localhost");
+                int port = config.getInt("database.port", 3306);
+                String db = config.getString("database.name", "changelog");
+                String user = config.getString("database.user", "root");
+                String pass = config.getString("database.password", "");
+                Class.forName("com.mysql.cj.jdbc.Driver");
+                connection = DriverManager.getConnection(
+                        "jdbc:mysql://" + host + ":" + port + "/" + db,
+                        user,
+                        pass);
+            } else {
+                Class.forName("org.sqlite.JDBC");
+                File file = new File(plugin.getDataFolder(), "changelog.db");
+                connection = DriverManager.getConnection("jdbc:sqlite:" + file.getAbsolutePath());
+            }
+            createTable();
+        } catch (Exception e) {
+            plugin.getLogger().severe("Could not connect to database: " + e.getMessage());
+        }
+    }
+
+    private void createTable() throws SQLException {
+        String sql = "CREATE TABLE IF NOT EXISTS changelog_entries (" +
+                "id INTEGER PRIMARY KEY AUTOINCREMENT," +
+                "date TIMESTAMP DEFAULT CURRENT_TIMESTAMP," +
+                "message TEXT NOT NULL" +
+                ")";
+        try (Statement stmt = connection.createStatement()) {
+            stmt.executeUpdate(sql);
+        }
+    }
+
+    public void addEntry(String message) {
+        String sql = "INSERT INTO changelog_entries(message) VALUES(?)";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setString(1, message);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().severe("Failed to add entry: " + e.getMessage());
+        }
+    }
+
+    public void removeEntry(int id) {
+        String sql = "DELETE FROM changelog_entries WHERE id=?";
+        try (PreparedStatement ps = connection.prepareStatement(sql)) {
+            ps.setInt(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            plugin.getLogger().severe("Failed to remove entry: " + e.getMessage());
+        }
+    }
+
+    public ResultSet getEntries() throws SQLException {
+        String sql = "SELECT * FROM changelog_entries ORDER BY id DESC";
+        Statement stmt = connection.createStatement();
+        return stmt.executeQuery(sql);
+    }
+
+    public void close() {
+        try {
+            if (connection != null && !connection.isClosed()) {
+                connection.close();
+            }
+        } catch (SQLException e) {
+            // ignore
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,7 @@
+database:
+  type: sqlite # "mysql" or "sqlite"
+  host: localhost
+  port: 3306
+  name: changelog
+  user: root
+  password: ''

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,0 +1,8 @@
+name: Changelog
+version: '1.0.0'
+main: at.dergamer09.changelog.ChangelogPlugin
+api-version: '1.21'
+commands:
+  changelog:
+    description: Manage or view changelog
+    usage: /changelog


### PR DESCRIPTION
## Summary
- add a changelog plugin storing entries in SQLite or MySQL
- implement `/changelog` commands to add, remove and list entries
- display entries in a paged GUI
- provide Maven build files and default config

## Testing
- `mvn -q -DskipTests package` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688bea78090c832e999745894b445915